### PR TITLE
update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Or, as stated on the main CSS modules page:
 Install using Meteor's package management system:
 
 ```bash
-meteor add wolasss:css-modules
+meteor add wolas:scss-modules
 ```
 
 By default, this plugin will handle .css files as well as .m.css and .mss files (legacy). This can be adjusted in the [package options](https://github.com/nathantreid/meteor-css-modules/wiki/Package-Options).

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 /* globals Package */
 Package.describe({
-  name: 'wolasss:css-modules',
+  name: 'wolas:scss-modules',
   version: '5.0.0',
   summary: 'CSS modules implementation. CSS for components!',
   git: 'https://github.com/wolasss/meteor-css-modules',


### PR DESCRIPTION
The instructions and `package.js` didn't match what was in [Atmosphere](https://atmospherejs.com/wolas/scss-modules).  The instructions wouldn't work and I think it is good form for the `package.js` to use a consistent name.

Thanks for publishing this. 